### PR TITLE
Added support for disallowed assignments

### DIFF
--- a/munkres.py
+++ b/munkres.py
@@ -591,10 +591,11 @@ class Munkres:
         minval = self.__find_smallest()
         for i in range(self.n):
             for j in range(self.n):
+                if self.C[i][j] is DISALLOWED:
+                    continue
                 if self.row_covered[i]:
                     self.C[i][j] += minval
-                if (not self.col_covered[j] and
-                    self.C[i][j] is not DISALLOWED):
+                if not self.col_covered[j]:
                     self.C[i][j] -= minval
         return 4
 

--- a/munkres.py
+++ b/munkres.py
@@ -319,6 +319,16 @@ DISALLOWED = DISALLOWED_OBJ()
 DISALLOWED_PRINTVAL = "D"
 
 # ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class UnsolvableMatrix(Exception):
+    """
+    Exception raised for unsolvable matrices
+    """
+    pass
+
+# ---------------------------------------------------------------------------
 # Classes
 # ---------------------------------------------------------------------------
 
@@ -589,14 +599,21 @@ class Munkres:
         lines.
         """
         minval = self.__find_smallest()
+        events = 0
         for i in range(self.n):
             for j in range(self.n):
                 if self.C[i][j] is DISALLOWED:
                     continue
                 if self.row_covered[i]:
                     self.C[i][j] += minval
+                    events += 1
                 if not self.col_covered[j]:
                     self.C[i][j] -= minval
+                    events += 1
+                if self.row_covered[i] and not self.col_covered[j]:
+                    events -= 2
+        if (events == 0):
+            raise UnsolvableMatrix("Matrix cannot be solved!")
         return 4
 
     def __find_smallest(self):

--- a/munkres.py
+++ b/munkres.py
@@ -599,7 +599,7 @@ class Munkres:
         lines.
         """
         minval = self.__find_smallest()
-        events = 0
+        events = 0 # track actual changes to matrix
         for i in range(self.n):
             for j in range(self.n):
                 if self.C[i][j] is DISALLOWED:
@@ -611,7 +611,7 @@ class Munkres:
                     self.C[i][j] -= minval
                     events += 1
                 if self.row_covered[i] and not self.col_covered[j]:
-                    events -= 2
+                    events -= 2 # change reversed, no real difference
         if (events == 0):
             raise UnsolvableMatrix("Matrix cannot be solved!")
         return 4

--- a/munkres.py
+++ b/munkres.py
@@ -228,8 +228,8 @@ Simply use the munkres.DISALLOWED constant.
     matrix = [[5, 9, DISALLOWED],
               [10, DISALLOWED, 2],
               [8, 7, 4]]
-    cost_matrix = make_cost_matrix(matrix, lambda cost: (sys.maxsize - cost) if 
-                                           (cost is DISALLOWED) else DISALLOWED)
+    cost_matrix = make_cost_matrix(matrix, lambda cost: (sys.maxsize - cost) if
+                                          (cost != DISALLOWED) else DISALLOWED)
     m = Munkres()
     indexes = m.compute(cost_matrix)
     print_matrix(matrix, msg='Lowest cost through this matrix:')
@@ -239,6 +239,17 @@ Simply use the munkres.DISALLOWED constant.
         total += value
         print '(%d, %d) -> %d' % (row, column, value)
     print 'total profit=%d' % total
+
+Running this program produces:
+
+    Lowest cost through this matrix:
+    [ 5,  9,  D]
+    [10,  D,  2]
+    [ 8,  7,  4]
+    (0, 1) -> 9
+    (1, 0) -> 10
+    (2, 2) -> 4
+    total profit=23
 
 References
 ==========
@@ -456,8 +467,8 @@ class Munkres:
             # Find the minimum value for this row and subtract that minimum
             # from every element in the row.
             for j in range(n):
-                if self.C[i][j] is not DISALLOWED: self.C[i][j] -= minval
-
+                if self.C[i][j] is not DISALLOWED:
+                    self.C[i][j] -= minval
         return 2
 
     def __step2(self):
@@ -582,7 +593,8 @@ class Munkres:
             for j in range(self.n):
                 if self.row_covered[i]:
                     self.C[i][j] += minval
-                if not self.col_covered[j]:
+                if (not self.col_covered[j] and
+                    self.C[i][j] is not DISALLOWED):
                     self.C[i][j] -= minval
         return 4
 

--- a/munkres.py
+++ b/munkres.py
@@ -288,7 +288,7 @@ import copy
 # Exports
 # ---------------------------------------------------------------------------
 
-__all__     = ['Munkres', 'make_cost_matrix']
+__all__     = ['Munkres', 'make_cost_matrix', 'DISALLOWED']
 
 # ---------------------------------------------------------------------------
 # Globals
@@ -302,7 +302,10 @@ __copyright__ = "(c) 2008 Brian M. Clapper"
 __license__   = "Apache Software License"
 
 # Constants
-DISALLOWED = "DISALLOWED"
+class DISALLOWED_OBJ(object):
+    pass
+DISALLOWED = DISALLOWED_OBJ()
+DISALLOWED_PRINTVAL = "D"
 
 # ---------------------------------------------------------------------------
 # Classes
@@ -738,18 +741,19 @@ def print_matrix(matrix, msg=None):
     for row in matrix:
         for val in row:
             if val is DISALLOWED:
-                val = "D"
+                val = DISALLOWED_PRINTVAL
             width = max(width, len(str(val)))
 
     # Make the format string
-    format = ('%%%dd' % width)
+    format = ('%%%d' % width)
 
     # Print the matrix
     for row in matrix:
         sep = '['
         for val in row:
-            if val is DISALLOWED: formatted = "D"
-            else: formatted = (format % val)
+            if val is DISALLOWED:
+                formatted = ((format + 's') % DISALLOWED_PRINTVAL)
+            else: formatted = ((format + 'd') % val)
             sys.stdout.write(sep + formatted)
             sep = ', '
         sys.stdout.write(']\n')
@@ -791,7 +795,14 @@ if __name__ == '__main__':
           [1, 9, 12, 11],
           [DISALLOWED, 5, 4, DISALLOWED],
           [12, 12, 12, 10]],
-         20)]
+         20),
+
+        # DISALLOWED to force pairings
+        ([[1, DISALLOWED, DISALLOWED, DISALLOWED],
+          [DISALLOWED, 2, DISALLOWED, DISALLOWED],
+          [DISALLOWED, DISALLOWED, 3, DISALLOWED],
+          [DISALLOWED, DISALLOWED, DISALLOWED, 4]],
+         10)]
 
     m = Munkres()
     for cost_matrix, expected_total in matrices:


### PR DESCRIPTION
Can now specify disallowed assignments for cost and profit matrices (using murkres.DISALLOWED constant), print matrices with disallowed assignments, and detect matrices rendered unsolvable by disallowed assignments.

Should resolve #19 