### PR TITLE
Python 3 compatibility: Leave DISALLOWED out of comparisons

### DIFF
--- a/munkres.py
+++ b/munkres.py
@@ -473,7 +473,7 @@ class Munkres:
         C = self.C
         n = self.n
         for i in range(n):
-            minval = min(self.C[i])
+            minval = min([x for x in self.C[i] if x is not DISALLOWED])
             # Find the minimum value for this row and subtract that minimum
             # from every element in the row.
             for j in range(n):
@@ -622,9 +622,10 @@ class Munkres:
         for i in range(self.n):
             for j in range(self.n):
                 if (not self.row_covered[i]) and (not self.col_covered[j]):
-                    if minval > self.C[i][j]:
+                    if self.C[i][j] is not DISALLOWED and minval > self.C[i][j]:
                         minval = self.C[i][j]
         return minval
+
 
     def __find_a_zero(self):
         """Find the first uncovered element with value 0"""


### PR DESCRIPTION
The library as it stands mostly works with Python 3, except for one thing: because Python 3 started [cracking down on unnatural comparisons](https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons), the `DISALLOWED` constant added in #19 no longer works. (It raises a `TypeError` for unorderable types, as is expected in Python 3.)

I assume this constant is meant to act like infinity, so this pull request just changes what I think are the two lines where it would otherwise try to make an illegal (in Python 3) comparison between a number and `DISALLOWED_OBJ()`, and gets it to behave as if `DISALLOWED` is always larger.

Thanks for your work on this package, it's really appreciated!