### PR TITLE
Search for uncovered zeros starting at the last one, not from (0,0)

### DIFF
--- a/munkres.py
+++ b/munkres.py
@@ -473,7 +473,7 @@ class Munkres:
         C = self.C
         n = self.n
         for i in range(n):
-            minval = min(self.C[i])
+            minval = min([x for x in self.C[i] if x is not DISALLOWED])
             # Find the minimum value for this row and subtract that minimum
             # from every element in the row.
             for j in range(n):
@@ -622,9 +622,10 @@ class Munkres:
         for i in range(self.n):
             for j in range(self.n):
                 if (not self.row_covered[i]) and (not self.col_covered[j]):
-                    if minval > self.C[i][j]:
+                    if self.C[i][j] is not DISALLOWED and minval > self.C[i][j]:
                         minval = self.C[i][j]
         return minval
+
 
     def __find_a_zero(self):
         """Find the first uncovered element with value 0"""

--- a/munkres.py
+++ b/munkres.py
@@ -532,11 +532,11 @@ class Munkres:
         """
         step = 0
         done = False
-        row = -1
-        col = -1
+        row = 0
+        col = 0
         star_col = -1
         while not done:
-            (row, col) = self.__find_a_zero()
+            (row, col) = self.__find_a_zero(row, col)
             if row < 0:
                 done = True
                 step = 6
@@ -627,16 +627,16 @@ class Munkres:
         return minval
 
 
-    def __find_a_zero(self):
+    def __find_a_zero(self, i0=0, j0=0):
         """Find the first uncovered element with value 0"""
         row = -1
         col = -1
-        i = 0
+        i = i0
         n = self.n
         done = False
 
         while not done:
-            j = 0
+            j = j0
             while True:
                 if (self.C[i][j] == 0) and \
                         (not self.row_covered[i]) and \
@@ -644,11 +644,11 @@ class Munkres:
                     row = i
                     col = j
                     done = True
-                j += 1
-                if j >= n:
+                j = (j + 1) % n
+                if j == j0:
                     break
-            i += 1
-            if i >= n:
+            i = (i + 1) % n
+            if i == i0:
                 done = True
 
         return (row, col)


### PR DESCRIPTION
This is a change to step 4: When it looks for a uncovered zero, rather than starting at row 0, column 0, it starts where it left off, _i.e._ at the last uncovered zero it found. Since it doesn't start at (0,0), when it gets to the last column it now loops around to the first, and exits unsuccessfully if it got back to where it started. It accomplishes this by passing in two arguments `i0, j0` to `self.__find_a_zero()`, namely, the last uncovered zero it checked.

I'm finding that this reduces the solving time for (certain) matrices of size 394×394 from about 2 minutes, to about 4 seconds, and (on a handful of test cases I have that go through step 4 dozens of times) gets the same result. I'd be happy to share those matrices with you if you like.

I _think_ this shouldn't functionally change the algorithm, other than to change the _order_ in which it searches through the matrix for an uncovered zero. I think the speed-up occurs because typically the next uncovered zero is at some point shortly after the last one (because in most cases it would've found it the last time if it before the last one). But I'm not an expert on the Hungarian algorithm, so would appreciate a second pair of eyes.

This pull request builds on (_i.e._ includes) #23. The two commits actually conflict if you try to merge them individually, so if you decide you want this one but not #23 let me know and I'll redo this one to be alone. (Though of course, I hope you'll take both!)

Let me know if you have any questions!