### PR TITLE
Ship the docs again

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 recursive-include html *
-include LICENSE README CHANGELOG
+include LICENSE.md README.md CHANGELOG.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-recursive-include html *
 recursive-include test *.md
 include LICENSE.md README.md CHANGELOG.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include html *
+recursive-include test *.md
 include LICENSE.md README.md CHANGELOG.md


### PR DESCRIPTION
Recent release sdists are missing the license, etc.

They were renamed to `.md`, but the `MANIFEST.in` wasn't updated.