### PR TITLE
[Fix] tests which aren't completely converted to pytest

### DIFF
--- a/test/test_munkres.py
+++ b/test/test_munkres.py
@@ -26,7 +26,7 @@ def float_example():
               [10.4, 3.5, 2.6],
               [8.7, 7.8, 4.9]]
     cost = _get_cost(matrix)
-    assert_almost_equal(cost, 13.5)
+    assert cost == pytest.approx(13.5)
 
 def test_5_x_5():
     matrix = [[12, 9, 27, 10, 23],


### PR DESCRIPTION
Fix tests which are missed by @bmc in c0fc2e3 commit<sup>[1]</sup>, to completely
convert all nose test to pytest<sup>[2]</sup>.

[1]: https://github.com/bmc/munkres/commit/c0fc2e3765e0a9598c6886326afff93153cdf628
[2]: https://github.com/bmc/munkres/pull/32/