### PR TITLE
Add conversion to list before padding, extend length of result

### DIFF
--- a/munkres.py
+++ b/munkres.py
@@ -100,7 +100,7 @@ class Munkres:
         new_matrix = []
         for row in matrix:
             row_len = len(row)
-            new_row = row[:]
+            new_row = list(row[:])
             if total_rows > row_len:
                 # Row too short. Pad it.
                 new_row += [pad_value] * (total_rows - row_len)
@@ -163,8 +163,8 @@ class Munkres:
 
         # Look for the starred columns
         results = []
-        for i in range(self.original_length):
-            for j in range(self.original_width):
+        for i in range(self.n):
+            for j in range(self.n):
                 if self.marked[i][j] == 1:
                     results += [(i, j)]
 


### PR DESCRIPTION
Hi, I've been using this repository for some time now and I found two things that did not work for me.

First, when passing a non-square numpy ndarray to the Munkres.compute() function, an error occurs because numpy arrays are not extendable. However, this only happens when there are more rows than columns because the column extension does not modify the original array.

```
from munkres import Munkres
import numpy as np

m = Munkres()

arr = np.array([[10, 2, 3],
                [4, 5, 7],
                [8, 9, 10],
                [11, 0, 1]])
munkres_tuples = m.compute(arr)
print(munkres_tuples)
```

So with this code we get:
```
  File "", line 202, in __step1
    if self.C[i][j] is not DISALLOWED:
IndexError: index 3 is out of bounds for axis 0 with size 3
```
because the array has not been padded correctly. 
The solution to this is changing line 103 from `new_row = row[:]` to `new_row = list(row[:])`, which is then extendable and can be padded correctly. Moreover, if `row[:]` is a list already, then nothing will happen.

The second thing is the output solution. The output of the above program is:
```
[(0, 2), (1, 0), (3, 1)]
```

However, since there is an additional row, we would like to also have the assignment for that row. This can be fixed by changing line 166 from `self.original_length` to `self.n` and line 167 from `self.original_width` to `self.n`. Then we obtain:

```
[(0, 2), (1, 0), (2, 3), (3, 1)]
```
