### PR TITLE
Implement check to prevent infinite loop cases

### DIFF
--- a/munkres.py
+++ b/munkres.py
@@ -133,6 +133,7 @@ class Munkres:
         A list of `(row, column)` tuples that describe the lowest cost path
         through the matrix
         """
+        self.__check_unsolvability(cost_matrix)
         self.C = self.pad_matrix(cost_matrix)
         self.n = len(self.C)
         self.original_length = len(cost_matrix)
@@ -180,6 +181,46 @@ class Munkres:
         for i in range(n):
             matrix += [[val for j in range(n)]]
         return matrix
+
+    def __transpose_matrix(self, matrix: Matrix):
+        return [list(row) for row in zip(*matrix)]
+
+    def __check_unsolvability(self, matrix: Matrix):
+        """Checks additional conditions to see if an input Munkres cost matrix is unsolvable.
+
+        This check identifies potential infinite loop edge cases and raises a ``munkres.UnsolvableMatrix`` error.
+
+
+        Args:
+            matrix (Matrix): a Matrix object, representing a cost matrix (or a profit matrix) suitable
+                for Munkres optimization.
+
+        Raises:
+            munkres.UnsolvableMatrix: if the matrix is unsolvable.
+        """
+
+        def _check_one_dimension_solvability(matrix):
+
+            non_disallowed_indices = []  # (in possibly-offending rows)
+
+            for row in matrix:
+
+                # check to see if all but 1 cell in the row are DISALLOWED
+
+                indices = [i for i, val in enumerate(row) if not isinstance(val, type(DISALLOWED))]
+
+                if len(indices) == 1:
+
+                    if indices[0] in non_disallowed_indices:
+                        raise UnsolvableMatrix(
+                            "This matrix cannot be solved and will loop infinitely"
+                        )
+
+                    non_disallowed_indices.append(indices[0])
+
+        _check_one_dimension_solvability(matrix)
+        transposed_matrix = self.__transpose_matrix(matrix)
+        _check_one_dimension_solvability(transposed_matrix)
 
     def __step1(self) -> int:
         """

--- a/test/test_munkres.py
+++ b/test/test_munkres.py
@@ -216,12 +216,27 @@ def test_rectangular_float():
     assert padded_cost == pytest.approx(cost)
     assert cost == pytest.approx(70.42)
 
-def test_unsolvable():
-    with pytest.raises(UnsolvableMatrix):
-        matrix = [[5, 9, DISALLOWED],
+
+@pytest.mark.parametrize(
+    "unsolvable_matrix",
+    (
+            [
+                [5, 9, DISALLOWED],
                 [10, DISALLOWED, 2],
-                [DISALLOWED, DISALLOWED, DISALLOWED]]
-        m.compute(matrix)
+                [DISALLOWED, DISALLOWED, DISALLOWED]
+            ],
+
+            [
+                [DISALLOWED, 161, DISALLOWED],
+                [DISALLOWED, 1, DISALLOWED],
+                [DISALLOWED, 157, DISALLOWED],
+                [37, DISALLOWED, 5]
+            ]
+    )
+)
+def test_unsolvable(unsolvable_matrix):
+    with pytest.raises(UnsolvableMatrix):
+        m.compute(unsolvable_matrix)
 
 def test_unsolvable_float():
     with pytest.raises(UnsolvableMatrix):


### PR DESCRIPTION
This code introduces a check to prevent infinite loop cases. In the test case added in 'test_unsolvable', the software looped infinitely rather than raising an error. I tested this and found that the error was occurring after the cost_matrix had been padded.

This seems to fix #28 